### PR TITLE
Update PCDesktopClient.json

### DIFF
--- a/PCDesktopClient.json
+++ b/PCDesktopClient.json
@@ -4234,7 +4234,7 @@
 	"FIntDelayBeforeFirstPostStatsSeconds": 180,
 	"FIntEducationalPopupDisplayMaxCount": 500000,
 	"FIntEnableBacktraceIOSV2": 100,
-	"FIntEnableCullableScene2HundredthPercent": 000,
+	"FIntEnableCullableScene2HundredthPercent": 0,
 	"FIntEnableFriendFooterOnHomePageV369": 100,
 	"FIntEnableTencentSignupCleanup": 100,
 	"FIntEnableVoiceChatRejoinOnBlockDelay": 3,


### PR DESCRIPTION
Raw file has a nonstandard JSON value 000.  Python's native `json` library is unable to interpret it.  This is not a comprehensive fix.

The bug is likely [over here](https://github.com/MaximumADHD/RCT-Source/blob/350bb8c56809f2dbce71605e49acadd5104b9e6c/src/Program.cs#L749).